### PR TITLE
Set configgin version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.
 	rm -f dumb-init_*.deb
 
 # Install configgin
-RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin"
+RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin --version 0.16.3"
 
 # Add additional configuration and scripts
 ADD monitrc.erb /opt/fissile/monitrc.erb


### PR DESCRIPTION
The build pipelines use the commit hash of this repo for the docker
image. We need to take the configgin version into account here, so we
decided to set it in the Dockerfile, rather than add another string to
the image's tag.